### PR TITLE
chore: Update Cloudflare provider to ~5.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,8 +6,8 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: hashicorp/setup-terraform@v1
-      - uses: actions/checkout@v2
+      - uses: hashicorp/setup-terraform@v3
+      - uses: actions/checkout@v6
       - run: terraform init
       - run: terraform validate
       - name: Init test directory

--- a/modules/exchange/main.tf
+++ b/modules/exchange/main.tf
@@ -1,24 +1,24 @@
-resource "cloudflare_record" "mx" {
-  zone_id   = var.zone_id
-  name      = var.name
-  value     = var.mx
-  type      = "MX"
-  priority  = 0
-  ttl       = 3600
+resource "cloudflare_dns_record" "mx" {
+  zone_id  = var.zone_id
+  name     = var.name
+  content  = var.mx
+  type     = "MX"
+  priority = 0
+  ttl      = 3600
 }
 
-resource "cloudflare_record" "spf" {
-  zone_id   = var.zone_id
-  name      = var.name
-  value     = "v=spf1 include:spf.protection.outlook.com -all"
-  type      = "TXT"
-  ttl       = 3600
+resource "cloudflare_dns_record" "spf" {
+  zone_id = var.zone_id
+  name    = var.name
+  content = "v=spf1 include:spf.protection.outlook.com -all"
+  type    = "TXT"
+  ttl     = 3600
 }
 
-resource "cloudflare_record" "autodiscover" {
-  zone_id   = var.zone_id
-  name      = "autodiscover${var.name == "@" ? "" : ".${var.name}"}"
-  value     = "autodiscover.outlook.com"
-  type      = "CNAME"
-  ttl       = 3600
+resource "cloudflare_dns_record" "autodiscover" {
+  zone_id = var.zone_id
+  name    = "autodiscover${var.name == "@" ? "" : ".${var.name}"}"
+  content = "autodiscover.outlook.com"
+  type    = "CNAME"
+  ttl     = 3600
 }

--- a/modules/exchange/terraform.tf
+++ b/modules/exchange/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     cloudflare = {
       source = "cloudflare/cloudflare"
-      version = "~> 3.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/mdm/main.tf
+++ b/modules/mdm/main.tf
@@ -1,15 +1,15 @@
-resource "cloudflare_record" "registration" {
-  zone_id  = var.zone_id
-  name     = "enterpriseregistration${var.name == "@" ? "" : ".${var.name}"}"
-  value    = "enterpriseregistration.windows.net"
-  type     = "CNAME"
-  ttl      = 3600
+resource "cloudflare_dns_record" "registration" {
+  zone_id = var.zone_id
+  name    = "enterpriseregistration${var.name == "@" ? "" : ".${var.name}"}"
+  content = "enterpriseregistration.windows.net"
+  type    = "CNAME"
+  ttl     = 3600
 }
 
-resource "cloudflare_record" "enrollment" {
-  zone_id  = var.zone_id
-  name     = "enterpriseenrollment${var.name == "@" ? "" : ".${var.name}"}"
-  value    = "enterpriseenrollment.manage.microsoft.com"
-  type     = "CNAME"
-  ttl      = 3600
+resource "cloudflare_dns_record" "enrollment" {
+  zone_id = var.zone_id
+  name    = "enterpriseenrollment${var.name == "@" ? "" : ".${var.name}"}"
+  content = "enterpriseenrollment.manage.microsoft.com"
+  type    = "CNAME"
+  ttl     = 3600
 }

--- a/modules/mdm/terraform.tf
+++ b/modules/mdm/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     cloudflare = {
       source = "cloudflare/cloudflare"
-      version = "~> 3.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/skype/main.tf
+++ b/modules/skype/main.tf
@@ -1,28 +1,26 @@
-resource "cloudflare_record" "sipdir-online" {
-  zone_id  = var.zone_id
-  name     = "sip${var.name == "@" ? "" : ".${var.name}"}"
-  value    = "sipdir.online.lync.com"
-  type     = "CNAME"
-  ttl      = 3600
+resource "cloudflare_dns_record" "sipdir-online" {
+  zone_id = var.zone_id
+  name    = "sip${var.name == "@" ? "" : ".${var.name}"}"
+  content = "sipdir.online.lync.com"
+  type    = "CNAME"
+  ttl     = 3600
 }
 
-resource "cloudflare_record" "webdir-online" {
-  zone_id  = var.zone_id
-  name     = "lyncdiscover${var.name == "@" ? "" : ".${var.name}"}"
-  value    = "webdir.online.lync.com"
-  type     = "CNAME"
-  ttl      = 3600
+resource "cloudflare_dns_record" "webdir-online" {
+  zone_id = var.zone_id
+  name    = "lyncdiscover${var.name == "@" ? "" : ".${var.name}"}"
+  content = "webdir.online.lync.com"
+  type    = "CNAME"
+  ttl     = 3600
 }
 
-resource "cloudflare_record" "sip-tls" {
-  zone_id  = var.zone_id
-  name     = var.name
-  type     = "SRV"
+resource "cloudflare_dns_record" "sip-tls" {
+  zone_id = var.zone_id
+  name    = "_sip._tls.${var.name == "@" ? "" : "${var.name}."}"
+  type    = "SRV"
+  ttl     = 3600
 
-  data {
-    service  = "_sip"
-    proto    = "_tls"
-    name     = var.name
+  data = {
     priority = 100
     weight   = 1
     port     = 443
@@ -30,15 +28,13 @@ resource "cloudflare_record" "sip-tls" {
   }
 }
 
-resource "cloudflare_record" "sipfederationtls-tcp" {
-  zone_id  = var.zone_id
-  name     = var.name
-  type     = "SRV"
+resource "cloudflare_dns_record" "sipfederationtls-tcp" {
+  zone_id = var.zone_id
+  name    = "_sipfederationtls._tcp.${var.name == "@" ? "" : "${var.name}."}"
+  type    = "SRV"
+  ttl     = 3600
 
-  data {
-    service  = "_sipfederationtls"
-    proto    = "_tcp"
-    name     = var.name
+  data = {
     priority = 100
     weight   = 1
     port     = 5061

--- a/modules/skype/terraform.tf
+++ b/modules/skype/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     cloudflare = {
       source = "cloudflare/cloudflare"
-      version = "~> 3.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/modules/verification/main.tf
+++ b/modules/verification/main.tf
@@ -1,7 +1,7 @@
-resource "cloudflare_record" "txt-verify" {
-  zone_id  = var.zone_id
-  name     = var.name
-  value    = var.verify
-  type     = "TXT"
-  ttl      = 3600
+resource "cloudflare_dns_record" "txt-verify" {
+  zone_id = var.zone_id
+  name    = var.name
+  content = var.verify
+  type    = "TXT"
+  ttl     = 3600
 }

--- a/modules/verification/terraform.tf
+++ b/modules/verification/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     cloudflare = {
       source = "cloudflare/cloudflare"
-      version = "~> 3.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     cloudflare = {
       source = "cloudflare/cloudflare"
-      version = "~> 3.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/test/config.tf
+++ b/test/config.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cloudflare = {
       source = "cloudflare/cloudflare"
-      version = "~> 3.0"
+      version = "~> 5.0"
     }
   }
 }

--- a/test/test.tf
+++ b/test/test.tf
@@ -1,5 +1,11 @@
+variable "account_id" {
+  type    = string
+  default = "example-account-id"
+}
+
 resource "cloudflare_zone" "example" {
-  zone = "example.com"
+  name    = "example.com"
+  account = { id = var.account_id }
 }
 
 module "test-ghpage" {
@@ -9,4 +15,3 @@ module "test-ghpage" {
 	verify   = "MS=ms123456"
 	mx       = "office-mycompany-tld.mail.protection.outlook.com"
 }
-


### PR DESCRIPTION
Upgrade Cloudflare Terraform provider version constraint from ~3.0 to ~5.0 across all modules (exchange, mdm, skype, verification), root module, and test configuration.

Also update GitHub Actions workflow to use hashicorp/setup-terraform@v3 and actions/checkout@v6.